### PR TITLE
📦 Add link check action

### DIFF
--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -1,0 +1,17 @@
+name: Link-check
+on:
+schedule:
+  - cron: '0 0 * * 1'  # every monday
+push:
+
+
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Run linksafe
+        uses: TechWiz-3/linksafe@fast
+        env:
+            TOKEN: ${{ secrets.TOKEN }}

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -1,8 +1,8 @@
 name: Link-check
 on:
-schedule:
-  - cron: '0 0 * * 1'  # every monday
-push:
+  schedule:
+    - cron: '0 0 * * 1'  # every monday
+  push:
 
 
 


### PR DESCRIPTION
In this PR, I have added a workflow which checks links and fails if any of them are broken.

Disclaimer: this action is my own action, the repo is [here](https://github.com/TechWiz-3/linksafe/tree/fast). Because of the very large amount of links, I'm using the 'fast' version/branch which simply requires a github token to be stored as `TOKEN` as a repo secret.

You can view the logs of the workflow on my fork [here](https://github.com/TechWiz-3/awesome-terminals/actions/runs/3120634781/jobs/5061360017). 9 links were found to be broken.

The workflow runs every-time an update is pushed as well as once a week on a Monday.

Let me know if you'd like me to change anything, any feedback is appreciated either way :)


<img width="397" alt="Screen Shot 2022-09-25 at 1 00 29 pm" src="https://user-images.githubusercontent.com/75515581/192126302-3f5cda7f-96b1-4591-83ee-59ec9355b079.png">
<img width="500" alt="Screen Shot 2022-09-25 at 1 00 41 pm" src="https://user-images.githubusercontent.com/75515581/192126301-559ec164-ce38-4dde-a953-93c7129d313b.png">
