### PR TITLE
add x-cmd to shells list

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Terminal Emulators
 - [PowerShell](https://github.com/PowerShell/PowerShell) - PowerShell for every system!
 - [xonsh](https://github.com/xonsh/xonsh) - 🐚 Python-powered, cross-platform, Unix-gazing shell
   [Z Shell](https://sourceforge.net/p/zsh/code/ci/master/tree/) - Zsh is a shell designed for interactive use, although it is also a powerful scripting language. [https://www.zsh.org/](https://www.zsh.org/)
+- [x-cmd](https://github.com/x-cmd/x-cmd) A vast and interesting collection of tools that can then bootstrap lots of other programs / functions in a consistent and structured way.
 
 ## Tools
 ### Bash

--- a/README.md
+++ b/README.md
@@ -105,7 +105,6 @@ Terminal Emulators
 - [PowerShell](https://github.com/PowerShell/PowerShell) - PowerShell for every system!
 - [xonsh](https://github.com/xonsh/xonsh) - 🐚 Python-powered, cross-platform, Unix-gazing shell
   [Z Shell](https://sourceforge.net/p/zsh/code/ci/master/tree/) - Zsh is a shell designed for interactive use, although it is also a powerful scripting language. [https://www.zsh.org/](https://www.zsh.org/)
-- [x-cmd](https://github.com/x-cmd/x-cmd) A vast and interesting collection of tools that can then bootstrap lots of other programs / functions in a consistent and structured way.
 
 ## Tools
 ### Bash
@@ -356,6 +355,7 @@ Terminal Emulators
  - [m-cli](https://github.com/rgcr/m-cli) -  Swiss Army Knife for macOS.
  - [pfetch](https://github.com/dylanaraps/pfetch) - 🐧 A pretty system information tool written in POSIX sh.
  - [termtile](https://github.com/apaszke/termtile) - Terminal window manager for OS X.
+ - [x-cmd](https://github.com/x-cmd/x-cmd) A vast and interesting collection of tools that can then bootstrap lots of other programs / functions in a consistent and structured way.
 ### Swift
  - [trash](https://github.com/sindresorhus/macos-trash) - Move files and folders to the trash.
 


### PR DESCRIPTION
Hi. Thank you for this collection of useful terminal programs!
I want to add x-cmd to the list.
I have searched the PRs of this repo and believe that this is not a duplicate.

x-cmd is a toolset implemented using posix shell and awk. It is very small in size and offers many interesting features.

**Tools Provided by x-cmd:**
  - [Wrappers for Common Commands (e.g., cd, ip, ps, tar, apt, brew)](https://x-cmd.com/mod/zuz): These wrapped commands are more intelligent and easier to use compared to the native commands.
  - [Lightweight Package Management Tool](https://x-cmd.com/pkg/): We have implemented a lightweight package management tool using shell and awk. Through it, you can quickly obtain most common software tools, such as jq, 7za, bat, nvim, python, node, go, etc.
  - [CLI for Useful Websites (e.g., github.com, cht.sh)](https://x-cmd.com/mod/cht): We have wrapped their APIs using shell and awk for daily use and to obtain corresponding services in scripts.
  - [AI Tools](https://x-cmd.com/mod/openai): We provide CLIs for ChatGPT, Gemini, Jina.ai, etc., and have wrapped corresponding shortcut commands for different application scenarios, such as `@gemini` for chatting with Gemini AI and `@zh` for using AI to translate specified content or command results.
