### PR TITLE
Add ink-web to Web section

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Terminal Emulators
 
 ### Web
  - [AnderShell 3000](https://github.com/andersevenrud/retro-css-shell-demo) - Retro looking terminal in CSS [https://crt.no/](https://crt.no/)
+ - [ink-web](https://github.com/cjroth/ink-web) - A browser-based runtime for Ink that renders React terminal UI apps in xterm.js.
  - [jQuery Terminal Emulator](https://github.com/jcubic/jquery.terminal) - library for creating web based terminals
  - [Xterm.js](https://github.com/xtermjs/xterm.js) - A terminal for the web. [https://xtermjs.org/](https://xtermjs.org/)
 


### PR DESCRIPTION
## Summary\n\nThis PR adds [ink-web](https://github.com/cjroth/ink-web) to the Web section of the awesome-terminals list.\n\nink-web is a browser-based runtime for [Ink](https://github.com/vadimdemedes/ink) (React for CLIs) that enables running Ink/React terminal UI apps directly in the browser using xterm.js. It bridges terminal UIs to the web, allowing developers to render their React-based CLI applications in any modern browser.\n\n- Free and open source (MIT licensed)\n- GitHub: https://github.com/cjroth/ink-web\n\nThe entry has been added in alphabetical order within the existing Web section.