### PR TITLE
Add Octo Terminal to macOS section

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Terminal Emulators
 - [MacTerm](https://www.macterm.net/) - Powerful replacement for macOS Terminal, supporting 24-bit color, standard graphics protocols and iTerm2 image sequences and color schemes.
 - [Mosh](https://github.com/mobile-shell/mosh) - Mobile Shell.
 - [Nterm](https://nterm.app) - The terminal built for Node.js developers. A modern terminal with built-in Node.js version management.
+- [Octo Terminal](https://github.com/johunsang/octo-terminal-releases) - AI-powered vibe coding terminal with built-in Claude, Codex, Ollama, split terminals, code editor, notes, SSH remote, and Telegram/Discord/Slack remote control. Built with Tauri v2 + React + Rust.
 - [Rio](https://github.com/raphamorim/rio) - A hardware-accelerated GPU terminal emulator powered by WebGPU, focusing to run in desktops and browsers.
 - [Tabby](https://github.com/Eugeny/tabby) - A terminal for a more modern age (formerly Terminus) [https://tabby.sh/](https://tabby.sh/)
 - [Termbar](https://github.com/vetelko/termbar) - TermBar puts the command line in your Menubar, allowing you to free up screen space, and use it with convinience.


### PR DESCRIPTION
## Add Octo Terminal

[Octo Terminal](https://github.com/johunsang/octo-terminal-releases) — AI-powered vibe coding terminal.

- Built-in AI: Claude, Codex, Ollama, Kimi in split terminals
- All-in-one: Terminal (xterm.js + WebGL) + Code editor (Monaco) + Markdown notes + browser
- SSH remote with PM2 server monitoring
- Remote control via Telegram, Discord, Slack
- 75 themes, 8 split layouts, Kanban board, voice input
- Cross-platform: macOS (Apple Silicon + Intel) + Windows
- Tech: Tauri v2 + React 19 + Rust + xterm.js

Download: https://github.com/johunsang/octo-terminal-releases/releases