### PR TITLE
Add zt terminal emulator

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Terminal Emulators
 - [yaft](https://github.com/uobikiemukot/yaft) - yet another framebuffer terminal.
 - [Yakuake](https://www.kde.org/applications/system/yakuake/) - Yakuake is a drop-down terminal emulator based on KDE Konsole technology.
 - [Zutty](https://github.com/tomscii/zutty) - Unicode terminal with correct VT emulation that uses OpenGL ES Compute Shaders.
+- [zt](https://github.com/midasdf/zt) - A minimal, ultra-fast terminal emulator written in Zig. 1,382 MB/s throughput, 3.5ms startup, 4.3MB RSS. Supports fbdev and X11 backends with 59K+ embedded glyphs.
 
 ### macOS
 - [Alacritty](https://github.com/jwilm/alacritty) - A cross-platform, GPU-accelerated terminal emulator.


### PR DESCRIPTION
## Add zt

[zt](https://github.com/midasdf/zt) is a minimal, ultra-fast terminal emulator written in pure Zig.

### Highlights
- **1,382 MB/s throughput** (44x faster than st)
- **3.5ms startup** (4.1x faster than xterm)
- **4.3MB peak RSS** — single static binary (2.8MB)
- Dual backend: Linux framebuffer (zero dependencies) and X11/XCB
- 59,635 embedded glyphs (CJK + Nerd Fonts)
- xterm-256color + 24-bit TrueColor
- XKB keyboard layout + XIM input method support

Added under the **Linux** section in alphabetical order.