### PR TITLE
Add Conterm to macOS terminals

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Terminal Emulators
 - [Alacritty](https://github.com/jwilm/alacritty) - A cross-platform, GPU-accelerated terminal emulator.
 - [Bobcat](https://github.com/ismail-yilmaz/Bobcat) - A modern, feature-rich, cross-platform terminal emulator built with U++ framework.
 - Cathode - **[DEPRECATED]** VINTAGE TERMINAL.
+- [Conterm](https://github.com/mahdiarfrm/conterm) - A modern macOS terminal built on libghostty, with Liquid Glass chrome, splittable panes, tab groups, and a command palette.
 - [Contour](https://contour-terminal.org/) - is a modern, actually fast, modal terminal emulator. It aims to be the daily driver of power users looking for modern terminal features.
 - [cool-retro-term](https://github.com/Swordfish90/cool-retro-term) - A good looking terminal emulator which mimics the old cathode display.
 - [eDEX-UI](https://github.com/GitSquared/edex-ui) - **[DEPRECATED]** A cross-platform, customizable science fiction terminal emulator with advanced monitoring & touchscreen support.


### PR DESCRIPTION
Adds [Conterm](https://github.com/mahdiarfrm/conterm) to the **macOS**
section, inserted alphabetically between Cathode and Contour.

Conterm is an open-source macOS terminal built on libghostty
(Ghostty's embeddable terminal core), written in Swift / SwiftUI.
Highlights: Liquid Glass chrome, splittable panes, tab groups,
command palette, configurable via the standard Ghostty config syntax.

- Repo: https://github.com/mahdiarfrm/conterm
- Site: https://mahdiarfrm.github.io/conterm/
- License: MIT
- Status: actively maintained (v1.0.1 released today)