### PR TITLE
Add Corterm to Web terminals

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ Terminal Emulators
 ### Web
  - [AnderShell 3000](https://github.com/andersevenrud/retro-css-shell-demo) - Retro looking terminal in CSS [https://crt.no/](https://crt.no/)
 - [electerm](https://github.com/electerm/electerm) - Terminal / ssh / sftp / ftp / telnet / serialport / RDP / VNC / Spice client(linux, mac, win). [https://electerm.org/](https://electerm.org/)
+ - [Corterm](https://github.com/monster-echo/CortexTerminal2) - Self-hosted remote terminal platform with browser-native xterm.js terminal, session persistence, multi-worker support, and native mobile apps (iOS, Android, HarmonyOS). MIT licensed, Docker deploy.
  - [jQuery Terminal Emulator](https://github.com/jcubic/jquery.terminal) - library for creating web based terminals
  - [Xterm.js](https://github.com/xtermjs/xterm.js) - A terminal for the web. [https://xtermjs.org/](https://xtermjs.org/)
 


### PR DESCRIPTION
Add [Corterm](https://github.com/monster-echo/CortexTerminal2) to the Web section.

Corterm is a self-hosted remote terminal platform:
- Browser-native xterm.js WebGL terminal
- Session persistence with detach/reattach
- Multi-worker support — connect any number of remote machines
- Native mobile apps (iOS, Android, HarmonyOS)
- MIT licensed, Docker deploy