### PR TITLE
Add jebi to macOS terminals

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Terminal Emulators
 - [Go2Shell](https://zipzapmac.com/Go2Shell) - Opens a terminal window to the current directory in Finder.
 - [Hyper](https://github.com/zeit/hyper) - A terminal built on web technologies.
 - [iTerm2](https://github.com/gnachman/iTerm2) iTerm2 is a terminal emulator for Mac OS X that does amazing things.
+- [jebi](https://github.com/jebi-sh/jebi) - jebi is a modern terminal emulator for Mac with built-in local AI.
 - [Kitty](https://github.com/kovidgoyal/kitty) - A cross-platform, fast, feature full, GPU based terminal emulator
 - [MOLTamp](https://moltamp.com/) - A skinnable cockpit shell that wraps AI terminal agents (Claude Code, Codex CLI, Gemini CLI, Aider, Cursor CLI) in a themeable UI with widgets, audio visualizers, and a community marketplace.
 - [MacTerm](https://www.macterm.net/) - Powerful replacement for macOS Terminal, supporting 24-bit color, standard graphics protocols and iTerm2 image sequences and color schemes.


### PR DESCRIPTION
Add [jebi](https://jebi.sh/) to macOS terminals.

jebi is a modern terminal emulator for Mac with built-in local AI.
 - automatically explains when a command fails.
 - suggest next commands to run.
 - convert natural language to commands
 - GPU-accelerated terminal via WebGL. 