### PR TITLE
Add OdyTTY to Linux terminals

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Terminal Emulators
 - [Konsole](https://konsole.kde.org/) - Konsole is a terminal emulator for the K Desktop Environment.
 - [Mosh](https://github.com/mobile-shell/mosh) - Mobile Shell.
 - [Notty](https://github.com/withoutboats/notty) - **[DEPRECATED]** A new kind of terminal.
+- [OdyTTY](https://github.com/ghreprimand/odytty) - A GPU-rendered terminal emulator for Linux (Rust/wgpu) with a theme builder, 100 themes, bloom/CRT/retro effects, and live in-app config. [https://odytty.unfinished-works.com/](https://odytty.unfinished-works.com/)
 - [QTerminal](https://github.com/lxqt/qterminal) - A lightweight Qt-based terminal emulator.
 - [Ptyxis](https://gitlab.gnome.org/chergert/ptyxis) - New Container-Focused Terminal Emulator for GNOME.
 - [Rio](https://github.com/raphamorim/rio) - A hardware-accelerated GPU terminal emulator powered by WebGPU, focusing to run in desktops and browsers. 


### PR DESCRIPTION
Adds OdyTTY to the Linux section.

OdyTTY is a from-scratch, GPU-rendered terminal emulator for Linux written in Rust (wgpu), focused on a distinctive visual identity and live in-app configuration rather than dotfile-only setup.

- Repo: https://github.com/ghreprimand/odytty
- Site: https://odytty.unfinished-works.com/
- License: GPL-3.0 · current release: v0.6.1

What's distinct vs. existing Linux entries: an in-app settings panel + theme builder (config files remain hand-editable), 100 built-in themes, optional bloom/CRT/retro effects, Kitty graphics + Sixel inline images, and splits/panes.

Placed alphabetically in the Linux list; single-line entry matching the existing `- [Name](url) - Description.` format with a trailing homepage link.
