### PR TITLE
Add Mobile SSH (Android + iOS terminal/SSH client)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ Terminal Emulators
 
 ### Android
 - [Android Terminal](https://source.android.com/docs/whatsnew/android-16-release#virtualization) - A built-in system app for running a Linux development environment within a virtual machine on Android.
+- [Mobile SSH](https://mobile-ssh.github.io/) - A focused SSH, SFTP, and terminal client for Android with multi-session terminals, a tmux manager, Eternal Terminal resilient sessions, and dual-pane file transfer.
 - [Termux](https://termux.com/) - Termux is an Android terminal emulator and Linux environment app that works directly with no rooting or setup required.
 - [Yetty](https://github.com/zokrezyl/yetty) - New generation terminal with remote graphics, remote GUI, rich scrolling buffer, plots, diagrams, etc.
 
@@ -14,6 +15,7 @@ Terminal Emulators
 - [Blink Shell](https://github.com/blinksh/blink) - Blink Mobile Shell for iOS (Mosh based) [https://blink.sh](https://blink.sh)
 - [ish](https://github.com/tbodt/ish) - Linux shell for iOS. [https://ish.app](https://ish.app)
 - [La Terminal](https://apps.apple.com/us/app/la-terminal/id1629902861) - More than just a simple command-line shell, La Terminal provides a fully-native, first-class touch experience for command-line hackers on iPhone and iPad. [https://blog.xibbon.com/welcome-to-la-terminal/](https://blog.xibbon.com/welcome-to-la-terminal/)
+- [Mobile SSH](https://mobile-ssh.github.io/) - A focused SSH, SFTP, and terminal client for iPhone and iPad with multi-session terminals, a tmux manager, Eternal Terminal resilient sessions, and dual-pane file transfer.
 - [Onepilot](https://onepilotapp.com) - An iOS terminal emulator with SSH client, designed for running Claude Code, Codex, and other CLI tools on remote servers. [https://onepilotapp.com](https://onepilotapp.com)
 - [Yetty](https://github.com/zokrezyl/yetty) - New generation terminal with remote graphics, remote GUI, rich scrolling buffer, plots, diagrams, etc.
 


### PR DESCRIPTION
Adds **Mobile SSH** to the Android and iOS terminal-emulator sections.

Mobile SSH is a focused SSH, SFTP, and terminal client for Android and iOS — multi-session terminal grid with xterm-256color emulation, a tmux session manager, Eternal Terminal resilient sessions, dual-pane SFTP transfer, local port forwarding, and hardware-keyboard support. Website: https://mobile-ssh.github.io/

- Added to both **### Android** and **### iOS** (the app ships on both, matching how cross-platform entries like Yetty appear in multiple sections).
- Inserted alphabetically in each section.
- Single-sentence bullets, format matching the surrounding entries.
- Links point to the project homepage, consistent with entries like Termux and Onepilot.

Thanks for maintaining the list!