### PR TITLE
Add WebSSH to web terminals

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ Terminal Emulators
  - [AnderShell 3000](https://github.com/andersevenrud/retro-css-shell-demo) - Retro looking terminal in CSS [https://crt.no/](https://crt.no/)
 - [electerm](https://github.com/electerm/electerm) - Terminal / ssh / sftp / ftp / telnet / serialport / RDP / VNC / Spice client(linux, mac, win). [https://electerm.org/](https://electerm.org/)
  - [jQuery Terminal Emulator](https://github.com/jcubic/jquery.terminal) - library for creating web based terminals
+ - [WebSSH](https://github.com/bifrost0x/webssh) - Security-focused, self-hosted SSH and SFTP workspace for homelabs and teams.
  - [WinkTerm](https://github.com/Cznorth/winkterm) - Self-hosted browser terminal (xterm.js) with shared PTY AI, SSH, and Agent HTTP API.
  - [Xterm.js](https://github.com/xtermjs/xterm.js) - A terminal for the web. [https://xtermjs.org/](https://xtermjs.org/)
  - [Yetty](https://github.com/zokrezyl/yetty) - New generation terminal with remote graphics, remote GUI, rich scrolling buffer, plots, diagrams, etc.


### PR DESCRIPTION
**Title:** Add WebSSH to Web terminals

Adds [[WebSSH](https://github.com/bifrost0x/webssh)](https://github.com/bifrost0x/webssh) to the Web section.

WebSSH is an open-source, self-hosted SSH and SFTP workspace that runs in the browser. It supports multiple SSH sessions, split panes, persistent tmux sessions, SFTP file management, encrypted SSH key storage, and multi-user deployments.

Project site: https://bifrost0x.github.io/webssh/

Disclosure: I am the maintainer of WebSSH.