### PR TITLE
Add MultiTerm

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ Terminal Emulators
 - [KiTTY](http://kitty.9bis.net/) - Fork from version 0.67 of PuTTY, the best telnet / SSH client in the world.
 - [MobaXterm](https://mobaxterm.mobatek.net/) - Enhanced terminal for Windows with X11 server, tabbed SSH client, network tools and much more.
 - [Mosh](https://github.com/mobile-shell/mosh) - Mobile Shell.
+- [MultiTerm](https://github.com/idk-arsh/multiterm) - Multi-pane terminal workspace with per-folder startup commands and broadcast typing, built on ConPTY.
 - [Rio](https://github.com/raphamorim/rio) - A hardware-accelerated GPU terminal emulator powered by WebGPU, focusing to run in desktops and browsers.
 - [PuTTY](https://www.chiark.greenend.org.uk/~sgtatham/putty/) - SSH and telnet client, developed originally by Simon Tatham for the Windows platform.
 - [Tabby](https://github.com/Eugeny/tabby) - A terminal for a more modern age (formerly Terminus) [https://tabby.sh/](https://tabby.sh/)


### PR DESCRIPTION
Adds MultiTerm under Windows, in alphabetical order.

Open source (MIT), Windows 10 and 11, built on ConPTY. Multi-pane with workspaces that remember a project's folders and startup commands, plus broadcast typing across panes.

Repo: https://github.com/idk-arsh/multiterm
